### PR TITLE
Fixed some bugs.

### DIFF
--- a/project/styles.css
+++ b/project/styles.css
@@ -54,7 +54,7 @@ body {
 }
 
 .card {
-    width: clamp(300px, 90vw, 400px);
+    width: clamp(330px, 90vw, 400px);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -174,4 +174,12 @@ body {
 
 .attribution__link:link {
     color: var(--clr-bright-blue)
+}
+
+/* Small media querie */
+
+@media (max-height: 803px) {
+    body {
+        margin-top: 50px;
+    }
 }


### PR DESCRIPTION
1.- When the viewport width was too small (smaller than 350px) the card__product element looked weird. I fixed it by changing the minimum width of the card to 330px.
2.- When the viewport height was too small (smaller than 800px) the container block did not have any spacing between it and the border of the viewport. I added a little media query that adds 50px of margin-top to the body when the viewport height is smaller than 803px.